### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Discord/Discord.pkg.recipe
+++ b/Discord/Discord.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.autopkg.mikestechshop.pkg.Discord</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.hnc.Discord</string>
 		<key>NAME</key>
 		<string>Discord</string>
 	</dict>

--- a/Ring Central/RingCentral.pkg.recipe
+++ b/Ring Central/RingCentral.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.autopkg.mikestechshop.pkg.RingCentral</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>us.zoom.ringcentral</string>
 		<key>NAME</key>
 		<string>RingCentral Phone</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Discord/Discord.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/mikestechshop-recipes/Discord/Discord.pkg.recipe
Processing repos/mikestechshop-recipes/Discord/Discord.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Discord.dmg',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_10_5) '
                                             'AppleWebKit/601.2.7 (KHTML, like '
                                             'Gecko) Version/9.0.1 '
                                             'Safari/601.2.7'},
           'url': 'https://discordapp.com/api/download?platform=osx'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/downloads/Discord.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/downloads/Discord.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/downloads/Discord.dmg/Discord.app',
           'requirement': 'identifier "com.hnc.Discord" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"53Q6R32WPB"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/downloads/Discord.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.yB1WaQ/Discord.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.yB1WaQ/Discord.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.yB1WaQ/Discord.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppDmgVersioner
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/downloads/Discord.dmg'}}
AppDmgVersioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/downloads/Discord.dmg
AppDmgVersioner: BundleID: com.hnc.Discord
AppDmgVersioner: Version: 0.0.261
{'Output': {'app_name': 'Discord.app',
            'bundleid': 'com.hnc.Discord',
            'version': '0.0.261'}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/Discord'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/Discord
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/Discord/Applications
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/Discord/Applications/Discord.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/downloads/Discord.dmg/Discord.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/downloads/Discord.dmg, dmg: .dmg/, dmg_source_path: Discord.app
Copier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/downloads/Discord.dmg
Copier: Copied /private/tmp/dmg.I8Bpi3/Discord.app to ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/Discord/Applications/Discord.app
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'chown': [{'group': 'admin',
                                      'path': 'Applications',
                                      'user': 'root'}],
                           'id': 'com.hnc.Discord',
                           'options': 'purge_ds_store',
                           'pkgname': 'Discord-0.0.261',
                           'version': '0.0.261'}}}
PkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/Discord-0.0.261.pkg.
PkgCreator: Existing package matches version and identifier, not building.
{'Output': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/Discord-0.0.261.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.Discord/receipts/Discord.pkg-receipt-20210213-233256.plist

Nothing downloaded, packaged or imported.
```

## ❌ Ring Central/RingCentral.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/mikestechshop-recipes/Ring\ Central/RingCentral.pkg.recipe
Processing repos/mikestechshop-recipes/Ring Central/RingCentral.pkg.recipe...
URLDownloader
{'Input': {'filename': 'RingCentral Phone.pkg',
           'url': 'https://app.ringcentral.com/download/RingCentral.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.RingCentral/downloads/RingCentral Phone.pkg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.RingCentral/downloads/RingCentral '
                        'Phone.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: RingCentral, '
                                        'Inc. (M932RC5J66)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.RingCentral/downloads/RingCentral '
                         'Phone.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "RingCentral Phone.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2020-12-30 23:37:06 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: RingCentral, Inc. (M932RC5J66)
CodeSignatureVerifier:        Expires: 2023-08-17 12:22:11 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            95 A7 2F C4 4F 3C BF 2C CB 8E 71 5D 94 0F EF 24 6A 00 EB 52 5A 99 
CodeSignatureVerifier:            45 4A 26 9F D7 EA A9 30 1C 43
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
AppDmgVersioner
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.RingCentral/downloads/RingCentral '
                       'Phone.pkg'}}
AppDmgVersioner: hdiutil imageinfo error hdiutil: imageinfo failed - image not recognized
 with image ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.RingCentral/downloads/RingCentral Phone.pkg.
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.RingCentral/receipts/RingCentral.pkg-receipt-20210213-233258.plist

The following recipes failed:
    repos/mikestechshop-recipes/Ring Central/RingCentral.pkg.recipe
        Error in com.github.autopkg.mikestechshop.pkg.RingCentral: Processor: AppDmgVersioner: Error: mounting ~/Library/AutoPkg/Cache/com.github.autopkg.mikestechshop.pkg.RingCentral/downloads/RingCentral Phone.pkg failed: hdiutil: attach failed - image not recognized

Nothing downloaded, packaged or imported.
```

