### PR TITLE
Update "DOWNLOAD_URL" to current x86_64 release

### DIFF
--- a/Dialpad/Dialpad.download.recipe
+++ b/Dialpad/Dialpad.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Dialpad</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://storage.googleapis.com/dialpad_native/osx/Dialpad.dmg</string>
+        <string>https://storage.googleapis.com/dialpad_native/osx/x64/Dialpad.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.4.1</string>


### PR DESCRIPTION
Looks like DialPad has released an x86_64 and ARM64 build of their software. Without digging deep to rework the logic of this recipe, I've just changed the download URL to point to the current x86_64 download. You could drop a comment into the recipe to note that the current url's are "https://storage.googleapis.com/dialpad_native/osx/arm64/Dialpad.dmg" and "https://storage.googleapis.com/dialpad_native/osx/x64/Dialpad.dmg" Cheers.Peet