### PR TITLE
Fix CloudFlare Warp Recipe

### DIFF
--- a/CloudFlare/CloudFlareWarp.download.recipe
+++ b/CloudFlare/CloudFlareWarp.download.recipe
@@ -37,26 +37,44 @@
 			<key>Processor</key>
 			<string>Unarchiver</string>
 		</dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unzip/Cloudflare*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>flat_pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/unzip/Cloudflare_WARP.pkg</string>
+				<string>%found_filename%</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>
 			<key>Processor</key>
 			<string>FlatPkgUnpacker</string>
 		</dict>
+		 <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/Cloudflare*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload</string>
 				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/Cloudflare_WARP.pkg/Payload</string>
+				<string>%found_filename%/Payload</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgPayloadUnpacker</string>

--- a/CloudFlare/CloudFlareWarp.pkg.recipe
+++ b/CloudFlare/CloudFlareWarp.pkg.recipe
@@ -27,12 +27,21 @@
 			<string>Versioner</string>
 		</dict>
 		<dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unzip/Cloudflare*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 				<key>source_pkg</key>
-				<string>%RECIPE_CACHE_DIR%/unzip/Cloudflare_WARP.pkg</string>
+				<string>%found_filename%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCopier</string>


### PR DESCRIPTION
Use FileFinder to determine .pkg names, accounting for CloudFlare's updated practice of including the version number in the package name. Fixes Issue #21 