### PR TITLE
More elegantly fix CloudFlare Warp recipe

### DIFF
--- a/CloudFlare/CloudFlareWarp.download.recipe
+++ b/CloudFlare/CloudFlareWarp.download.recipe
@@ -52,29 +52,20 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>flat_pkg_path</key>
-				<string>%found_filename%</string>
+				<string>%RECIPE_CACHE_DIR%/unzip/%found_basename%</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>
 			<key>Processor</key>
 			<string>FlatPkgUnpacker</string>
 		</dict>
-		 <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/Cloudflare*.pkg</string>
-            </dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload</string>
 				<key>pkg_payload_path</key>
-				<string>%found_filename%/Payload</string>
+				<string>%RECIPE_CACHE_DIR%/unpack/%found_basename%/Payload</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgPayloadUnpacker</string>

--- a/CloudFlare/CloudFlareWarp.pkg.recipe
+++ b/CloudFlare/CloudFlareWarp.pkg.recipe
@@ -27,21 +27,12 @@
 			<string>Versioner</string>
 		</dict>
 		<dict>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unzip/Cloudflare*.pkg</string>
-            </dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-        </dict>
-		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 				<key>source_pkg</key>
-				<string>%found_filename%</string>
+				<string>%RECIPE_CACHE_DIR%/unzip/%found_basename%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCopier</string>


### PR DESCRIPTION
I realized that the found_basename output exists from the FileFinder process, which allows a significantly more elegant solution than my previous PR to fix Issue #22 