### PR TITLE
Revert "More elegantly fix CloudFlare Warp recipe"

### DIFF
--- a/CloudFlare/CloudFlareWarp.download.recipe
+++ b/CloudFlare/CloudFlareWarp.download.recipe
@@ -52,20 +52,29 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>flat_pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/unzip/%found_basename%</string>
+				<string>%found_filename%</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>
 			<key>Processor</key>
 			<string>FlatPkgUnpacker</string>
 		</dict>
+		 <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/Cloudflare*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload</string>
 				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/%found_basename%/Payload</string>
+				<string>%found_filename%/Payload</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgPayloadUnpacker</string>

--- a/CloudFlare/CloudFlareWarp.pkg.recipe
+++ b/CloudFlare/CloudFlareWarp.pkg.recipe
@@ -27,12 +27,21 @@
 			<string>Versioner</string>
 		</dict>
 		<dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unzip/Cloudflare*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 				<key>source_pkg</key>
-				<string>%RECIPE_CACHE_DIR%/unzip/%found_basename%</string>
+				<string>%found_filename%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCopier</string>


### PR DESCRIPTION
Reverts autopkg/mikestechshop-recipes#23

The latest CloudFlare update has broken things again. Unfortunately the more "elegant" solution is not the most flexible. Reverting this commit to go back to a more ham-handed approach of determining filenames will make the recipe more robust while CloudFlare continues to figure out what practices they will use for updates going forwards.

Fixes Issue #25 