### PR TITLE
Deprecate redundant Dockutil.download recipe

### DIFF
--- a/Dockutil/Dockutil.download.recipe
+++ b/Dockutil/Dockutil.download.recipe
@@ -15,6 +15,15 @@
 	<string>1.0.4</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Dockutil recipes in the jessepeterson-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
The Dockutil.download recipe in this repo is similar in function to the earlier-created one in jessepeterson-recipes. This PR deprecates the one in this repo.

This consolidation will help simplify search results and lower maintenance effort. Thank you!