### PR TITLE
Avoid using NAME var in file paths

### DIFF
--- a/Tandem/TandemChat.download.recipe
+++ b/Tandem/TandemChat.download.recipe
@@ -43,7 +43,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/unpack/Tandem.app</string>
                 <key>requirement</key>
                 <string>identifier "tandem.app" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "W4VPC5PHQ9"</string>
                 <key>strict_verification</key>

--- a/Xink/Xink.download.recipe
+++ b/Xink/Xink.download.recipe
@@ -54,7 +54,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/payload/Xink.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.emailsignature.Xink" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = F287823HVS)</string>
                 <key>strict_verification</key>

--- a/i1Profiler/i1Profiler.pkg.recipe
+++ b/i1Profiler/i1Profiler.pkg.recipe
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/payload/Applications/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/payload/Applications/%NAME%/i1Profiler.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.