### PR TITLE
Add missing EndOfCheckPhase process

### DIFF
--- a/Asana/Asana.download.recipe
+++ b/Asana/Asana.download.recipe
@@ -36,6 +36,10 @@ universal (default): https://desktop-downloads.asana.com/darwin_universal/prod/l
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>

--- a/DF Studio/DFStudioDownloader.download.recipe
+++ b/DF Studio/DFStudioDownloader.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
It's important to include an [EndOfCheckPhase](https://github.com/autopkg/autopkg/wiki/Processor-EndOfCheckPhase) process after downloading is complete, in order to allow AutoPkg's `--check` feature to work properly.

This is especially important for users of [Cloud AutoPkg Runner](https://github.com/MScottBlake/cloud-autopkg-runner/), as that tool will fail any recipe that lacks an EndOfCheckPhase by default.