### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/homebysix/pre-commit-macadmin
+    rev: v1.21.1
+    hooks:
+      - id: check-autopkg-recipes
+        args: ["--recipe-prefix", "com.github.mikestechshop.", "com.github.autopkg.mikestechshop.", "--strict", "--"]
+      - id: forbid-autopkg-overrides
+      - id: forbid-autopkg-trust-info


### PR DESCRIPTION
This PR adds a pre-commit configuration, which can be used to automatically ensure AutoPkg recipes in this repo meet certain standards before `git commit` is executed.

In order to start using pre-commit, install it if you don't already have it (`brew install pre-commit`) and then `cd` to your recipe repo and run `pre-commit install` to activate the hooks.

For details on using pre-commit with AutoPkg, see this post: https://www.elliotjordan.com/posts/pre-commit-02-autopkg/

With the changes from #35 and #36 merged, the hooks should pass:

```
% pre-commit run --all-files
Check AutoPkg Recipes....................................................Passed
```