### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Asana/Asana.download.recipe
+++ b/Asana/Asana.download.recipe
@@ -36,6 +36,10 @@ universal (default): https://desktop-downloads.asana.com/darwin_universal/prod/l
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>

--- a/Automox/Automox.download.recipe
+++ b/Automox/Automox.download.recipe
@@ -27,6 +27,10 @@
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
@@ -64,10 +68,6 @@
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/Box/BoxNotes.download.recipe
+++ b/Box/BoxNotes.download.recipe
@@ -27,6 +27,10 @@
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
@@ -49,10 +53,6 @@
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/CloudFlare/CloudFlareWarp.download.recipe
+++ b/CloudFlare/CloudFlareWarp.download.recipe
@@ -27,6 +27,10 @@
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
@@ -71,10 +75,6 @@
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/DF Studio/DFStudioDownloader.download.recipe
+++ b/DF Studio/DFStudioDownloader.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>

--- a/Efficient Elements/Efficient Elements.download.recipe
+++ b/Efficient Elements/Efficient Elements.download.recipe
@@ -30,6 +30,10 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
 			<dict>
@@ -42,10 +46,6 @@
 				<key>input_path</key>
 				<string>%pathname%</string>
 			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/Iconik/IconikAgent.download.recipe
+++ b/Iconik/IconikAgent.download.recipe
@@ -28,6 +28,10 @@
                 <string>%NAME%-%ARCH%.dmg</string>
             </dict>
         </dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
         <dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>
@@ -41,10 +45,6 @@
                 <string>identifier "io.iconik.desktopagent" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5LDVD44GKB"</string>
             </dict>
         </dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
     </array>
 </dict>
 </plist>

--- a/Jump Desktop/JumpDesktop.download.recipe
+++ b/Jump Desktop/JumpDesktop.download.recipe
@@ -28,6 +28,10 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>Unarchiver</string>
 			<key>Arguments</key>
 			<dict>
@@ -50,10 +54,6 @@
                 <true/>
             </dict>
         </dict>
-        <dict>
-        		<key>Processor</key>
-        		<string>EndOfCheckPhase</string>
-        	</dict>
 	</array>
 </dict>
 </plist>

--- a/Tandem/TandemChat.download.recipe
+++ b/Tandem/TandemChat.download.recipe
@@ -27,6 +27,10 @@
             </dict>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
         	<key>Processor</key>
         	<string>Unarchiver</string>
         	<key>Arguments</key>
@@ -49,10 +53,6 @@
                 <key>strict_verification</key>
                 <true/>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Xink/Xink.download.recipe
+++ b/Xink/Xink.download.recipe
@@ -26,7 +26,11 @@
                 <string>%NAME%.pkg</string>
             </dict>
         </dict>
-         <dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>FlatPkgUnpacker</string>
             <key>Arguments</key>
@@ -37,7 +41,7 @@
                 <string>%RECIPE_CACHE_DIR%/unpack</string>
             </dict>
         </dict>
-         <dict>
+        <dict>
             <key>Processor</key>
             <string>PkgPayloadUnpacker</string>
             <key>Arguments</key>
@@ -48,7 +52,7 @@
                 <string>%RECIPE_CACHE_DIR%/payload</string>
             </dict>
         </dict>
-       <dict>
+        <dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
@@ -62,10 +66,6 @@
                 <key>deep_verification</key>
                 <true/>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.